### PR TITLE
fix: SSR window guards and missing ? prefix in useSyncMissingSearchPa…

### DIFF
--- a/packages/react-url-search-state/src/helpers.ts
+++ b/packages/react-url-search-state/src/helpers.ts
@@ -1,5 +1,5 @@
 import type { AnySearch } from "./types";
-import { createStoreKey, stringifyValue } from "./utils";
+import { createStoreKey, isBrowser, stringifyValue } from "./utils";
 
 /**
  * Saves selected search params to localStorage/sessionStorage.
@@ -15,6 +15,7 @@ export function persistSearchParamsToStorage(
   } = {},
 ) {
   const { namespace, storage = "local" } = options;
+  if (!isBrowser) return;
   const store = window[`${storage}Storage`];
   for (const name of names) {
     const searchValue = nextSearch[name];

--- a/packages/react-url-search-state/src/useSyncMissingSearchParams.ts
+++ b/packages/react-url-search-state/src/useSyncMissingSearchParams.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 import { useSearchStateContext } from "./context";
 import { debug } from "./debug";
 import type { AnySearch } from "./types";
-import { createStoreKey, parseSearch, stringifyValue } from "./utils";
+import { createStoreKey, isBrowser, parseSearch, stringifyValue } from "./utils";
 import type { ValidateSearchFn } from "./validation";
 
 export type UseSyncMissingSearchParamsOptions<
@@ -43,7 +43,7 @@ export const useSyncMissingSearchParams = <
       const { storage, storageNamespace } = config;
 
       let value = searchState[name];
-      if (storage) {
+      if (storage && isBrowser) {
         const store = window[`${storage}Storage`];
         const storeKey = createStoreKey(name, storageNamespace);
         const storeValue = store.getItem(storeKey);
@@ -75,7 +75,7 @@ export const useSyncMissingSearchParams = <
       Object.entries(missing).forEach(([name, value]) => {
         searchParams.set(name, value);
       });
-      replaceState(undefined, { search: searchParams.toString() });
+      replaceState(undefined, { search: `?${searchParams.toString()}` });
     }
   }, [location.search, validateSearch]);
 };

--- a/packages/react-url-search-state/src/utils.ts
+++ b/packages/react-url-search-state/src/utils.ts
@@ -1,3 +1,5 @@
+export const isBrowser = typeof window !== "undefined";
+
 type OptionalKeys<T> = {
   [K in keyof T]-?: undefined extends T[K] ? K : never;
 }[keyof T];


### PR DESCRIPTION
…rams

- Add isBrowser helper to utils.ts for safe window access
- Replace direct window usage with isBrowser guards throughout adapters
- Fix missing ? prefix bug in useSyncMissingSearchParams

Closes #5