### PR TITLE
fix: resolve namespace/storageNamespace naming inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Restores missing search params from `localStorage` or `sessionStorage` on mount.
 useSyncMissingSearchParams({
   params: {
     sort: { storage: "local" },
-    q: { storage: "session", storageNamespace: "my-app" },
+    q: { storage: "session", namespace: "my-app" },
   },
 });
 ```

--- a/packages/react-url-search-state/README.md
+++ b/packages/react-url-search-state/README.md
@@ -266,7 +266,7 @@ Restores missing search params from `localStorage` or `sessionStorage` on mount.
 useSyncMissingSearchParams({
   params: {
     sort: { storage: "local" },
-    q: { storage: "session", storageNamespace: "my-app" },
+    q: { storage: "session", namespace: "my-app" },
   },
 });
 ```

--- a/packages/react-url-search-state/src/useSyncMissingSearchParams.ts
+++ b/packages/react-url-search-state/src/useSyncMissingSearchParams.ts
@@ -14,7 +14,7 @@ export type UseSyncMissingSearchParamsOptions<
     string,
     {
       storage?: "local" | "session";
-      storageNamespace?: string;
+      namespace?: string;
     }
   >;
 };
@@ -40,12 +40,12 @@ export const useSyncMissingSearchParams = <
     let missing: Record<string, string> = {};
     Object.entries(paramsRef.current).forEach(([name, config]) => {
       if (searchParams.has(name)) return;
-      const { storage, storageNamespace } = config;
+      const { storage, namespace } = config;
 
       let value = searchState[name];
       if (storage && isBrowser) {
         const store = window[`${storage}Storage`];
-        const storeKey = createStoreKey(name, storageNamespace);
+        const storeKey = createStoreKey(name, namespace);
         const storeValue = store.getItem(storeKey);
 
         if (storeValue !== null) {


### PR DESCRIPTION
Resolves #9 

Standardizes the `namespace`/`storageNamespace` naming across adapters, hooks, and type definitions to expose a consistent public API surface.

## Changes
- Renamed `[old]` → `[canonical]` across all affected files
- Updated type definitions and JSDoc references accordingly

## Notes
- ⚠️ Breaking change for any consumers using the deprecated name — update direct usage accordingly
- No behavioral changes; purely a naming/consistency fix