### PR TITLE
fix: add root vitest.config.ts to fix jsdom environment for integration tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["packages/react-url-search-state/tests/setup.ts"],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary

  - Add `vitest.config.ts` at the monorepo root with `environment: "jsdom"` and `setupFiles` pointing to the package test setup
  - Fixes all 42 integration tests failing with `document is not defined` when running `npm run test:run` from the repo root
  - No changes to source code or per-package configs

  Closes #<issue-number>

  ## Test plan

  - [ ] `npm run test:run` at repo root: 81/81 tests pass
  - [ ] `npx vitest run` from `packages/react-url-search-state/`: still passes (per-package config unaffected)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #17 