### PR TITLE
fix: cleanSearchObject leaves empty objects in arrays after cleaning

### DIFF
--- a/packages/react-url-search-state/src/utils.ts
+++ b/packages/react-url-search-state/src/utils.ts
@@ -227,6 +227,14 @@ export function isPlainArray(value: unknown): value is Array<unknown> {
   return Array.isArray(value) && value.length === Object.keys(value).length;
 }
 
+export function isEmptyObject(value: unknown): value is Record<string, never> {
+  return typeof value === "object" && value !== null && Object.keys(value).length === 0;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Recursively removes `undefined` values from an object.
  *
@@ -241,17 +249,12 @@ export function cleanSearchObject(input: Record<string, unknown>) {
 
     if (Array.isArray(value)) {
       const cleanedArray = value
-        .map((v) =>
-          typeof v === "object" && v !== null
-            ? cleanSearchObject(v as Record<string, unknown>)
-            : v,
-        )
-        .filter((v) => v !== undefined);
+        .map((v) => isRecord(v) ? cleanSearchObject(v) : v)
+        .filter((v) => v !== undefined && !isEmptyObject(v));
 
       result[key] = cleanedArray;
-    } else if (typeof value === "object" && value !== null) {
-      const cleanedObj = cleanSearchObject(value as Record<string, unknown>);
-      result[key] = cleanedObj;
+    } else if (isRecord(value)) {
+      result[key] = cleanSearchObject(value);
     } else {
       result[key] = value;
     }

--- a/packages/react-url-search-state/tests/cleanSearchObject.test.ts
+++ b/packages/react-url-search-state/tests/cleanSearchObject.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { cleanSearchObject } from "../src/utils";
+
+describe("cleanSearchObject", () => {
+  it("removes top-level undefined values", () => {
+    expect(cleanSearchObject({ a: 1, b: undefined, c: "x" })).toEqual({
+      a: 1,
+      c: "x",
+    });
+  });
+
+  it("keeps falsy non-undefined values", () => {
+    expect(cleanSearchObject({ a: 0, b: false, c: null, d: "" })).toEqual({
+      a: 0,
+      b: false,
+      c: null,
+      d: "",
+    });
+  });
+
+  it("recursively cleans nested objects", () => {
+    expect(
+      cleanSearchObject({ nested: { x: undefined, y: 2 } }),
+    ).toEqual({ nested: { y: 2 } });
+  });
+
+  it("removes undefined items from arrays", () => {
+    expect(cleanSearchObject({ arr: [1, undefined, 3] })).toEqual({
+      arr: [1, 3],
+    });
+  });
+
+  it("filters out empty objects produced by cleaning array items", () => {
+    // Previously [{ x: undefined }] became [{}] — now it should become []
+    expect(cleanSearchObject({ arr: [{ x: undefined }] })).toEqual({
+      arr: [],
+    });
+  });
+
+  it("keeps non-empty cleaned objects in arrays", () => {
+    expect(
+      cleanSearchObject({ arr: [{ x: undefined, y: 1 }, { x: undefined }] }),
+    ).toEqual({ arr: [{ y: 1 }] });
+  });
+
+  it("handles arrays of primitives and objects together", () => {
+    expect(
+      cleanSearchObject({
+        arr: [1, { a: undefined }, "keep", { b: 2, c: undefined }],
+      }),
+    ).toEqual({ arr: [1, "keep", { b: 2 }] });
+  });
+
+  it("returns an empty object when all keys are undefined", () => {
+    expect(cleanSearchObject({ a: undefined, b: undefined })).toEqual({});
+  });
+
+  it("preserves nested arrays as-is rather than converting them to keyed objects", () => {
+    expect(cleanSearchObject({ arr: [[1, 2], [3, 4]] })).toEqual({
+      arr: [[1, 2], [3, 4]],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

  - Fixes `[{ x: undefined }]` becoming `[{}]` after `cleanSearchObject` — empty objects produced by recursive cleaning are now filtered out of arrays
  - Introduces `isEmptyObject` and `isRecord` type guards alongside the existing `isPlainObject`/`isPlainArray` predicates, eliminating all `as` assertions in
  `cleanSearchObject`
  - Fixes a latent bug where nested arrays inside array-valued params were silently converted to keyed objects; `isRecord` correctly excludes arrays from
  recursive cleaning

  ## Test plan

  - [x] All existing tests pass (`npm run test:run`)
  - [x] `[{ x: undefined }]` cleans to `[]`, not `[{}]` — covered by `"filters out empty objects produced by cleaning array items"`
  - [x] Nested arrays are preserved as-is — covered by `"preserves nested arrays as-is rather than converting them to keyed objects"`
  - [x] 9 new tests in `cleanSearchObject.test.ts` cover all cases end-to-end

  🤖 Generated with [Claude Code](https://claude.com/claude-code)