### PR TITLE
fix: add getServerSnapshot to useSyncExternalStore in useSearch

### DIFF
--- a/packages/react-url-search-state/src/useSearch.ts
+++ b/packages/react-url-search-state/src/useSearch.ts
@@ -72,7 +72,7 @@ export function useSearch<
     return validated;
   }, [cache, store]);
 
-  return useSyncExternalStore(store.subscribe, getSnapshot) as UseSearchResult<
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot) as UseSearchResult<
     TValidateSearchFn,
     TSelected
   >;


### PR DESCRIPTION
## Summary

  - Passes `getSnapshot` as the third `getServerSnapshot` argument to `useSyncExternalStore` in `useSearch`
  - Adds a `renderToString` integration test covering the SSR rendering path
  - Updates AUDIT.md to mark the medium-severity item as resolved

  ## Why this fix is safe

  `SearchStore` is initialized with `location.search` inside `SearchStateProviderInner` at mount time. In SSR contexts, the adapter provides the server-side URL,
  so the store is pre-seeded before any rendering occurs. `getSnapshot` therefore returns the correct validated state on the server — making it a valid
  `getServerSnapshot` with no hydration mismatch risk.

  ## Test plan

  - [x] All 92 tests pass (`npm run test:run`)
  - [x] New `"renders correctly during SSR via renderToString"` test passes — verifies `renderToString` does not throw and renders the correct validated search
  state

  Closes #23 

  🤖 Generated with [Claude Code](https://claude.com/claude-code)