### PR TITLE
docs: document type-first, runtime-optional validation philosophy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,17 @@ Adapters are thin wrappers around router-specific hooks (`useLocation`, `useNavi
 - `useSearchParamState` — `useState`-like API for a single param
 - `buildSearchString` — pure utility for generating validated URL search strings for link building
 
+### Strictness Philosophy (Confirmed Alignment with @tanstack/react-router)
+
+This library mirrors @tanstack/react-router's search param strictness model: **type-first, runtime-optional**.
+
+1. **TypeScript enforcement is strong.** `defineValidateSearch` produces `ValidateSearchFn<T>` which flows through all hooks via generics. Invalid usage is caught at compile time.
+2. **Runtime enforcement is optional.** `ValidationError` is only thrown when a provided validator function fails. No validator = no runtime error. Parse errors are silent.
+3. **Default parsing is permissive.** `parseSearch` uses JSON-ish parsing with silent fallback — failed JSON parse leaves the value as a string. Type coercion (`"true"` → `true`, `"123"` → `123`) is lenient.
+4. **Unknown params are allowed.** The parser returns all decoded params; the validator returns only declared fields. No strict-mode rejection exists.
+
+This gives strong editor feedback while keeping runtime behavior configurable — tight TS types for DX, runtime validation only when a validator is provided, and a forgiving default serializer.
+
 ### Other Key Patterns
 
 - **Factory:** `createSearchUtils()` pre-binds all hooks and utilities to a specific validator

--- a/packages/react-url-search-state/src/utils.ts
+++ b/packages/react-url-search-state/src/utils.ts
@@ -64,14 +64,16 @@ function parseSearchWith(parser: (str: string) => any) {
 
     const query: Record<string, unknown> = decode(searchStr);
 
-    // Try to parse any query params that might be json
+    // Try to parse any query params that might be json.
+    // Failures are intentionally silent — unparseable values stay as strings.
+    // This matches @tanstack/react-router's permissive default parser behavior.
     for (const key in query) {
       const value = query[key];
       if (typeof value === "string") {
         try {
           query[key] = parser(value);
         } catch (err) {
-          //
+          // Intentionally silent: value remains as-is (string).
         }
       }
     }
@@ -107,7 +109,7 @@ export function stringifySearchWith(
       try {
         return stringify(val);
       } catch (err) {
-        // silent
+        // Intentionally silent: unstringifiable values pass through as-is.
       }
     } else if (typeof val === "string" && typeof parser === "function") {
       try {
@@ -116,7 +118,7 @@ export function stringifySearchWith(
         parser(val);
         return stringify(val);
       } catch (err) {
-        // silent
+        // Intentionally silent: non-round-trippable strings pass through as-is.
       }
     }
     return val;


### PR DESCRIPTION
  ## Summary

  - Added **"How Validation Works"** section to the README explaining the strictness model with permissive vs. strict validator examples
  - Updated `defineValidateSearch` and `ValidationError` API sections to clarify when runtime errors occur vs. when parsing is silent
  - Added explanatory comments to silent `catch` blocks in `utils.ts` attributing the permissive design to @tanstack/react-router parity
  - Updated `CLAUDE.md` and `AGENTS.md` with a "Strictness Philosophy" section for contributors and agents

  No runtime behavior was changed.

  ## Context

  A cross-reference audit against the @tanstack/react-router codebase confirmed this library intentionally mirrors its strictness model: tight TypeScript types
  for DX, runtime validation only when a validator is provided, and a forgiving default serializer. This was previously undocumented.

  ## Test plan
  - [x] `npm run test:run` passes (92 tests, no regressions — docs and comments only)
  - [x] README renders correctly (check "How Validation Works" section and API entries)

Closes #25 