### PR TITLE
  feat: expose setDebug() for runtime-toggleable debug logging

### DIFF
--- a/packages/react-url-search-state/src/debug.ts
+++ b/packages/react-url-search-state/src/debug.ts
@@ -1,14 +1,24 @@
-export const DEBUG = (() => {
-  try {
-    return localStorage.getItem("react-url-search-state:debug") !== null;
-  } catch {
-    return false;
-  }
-})();
+let debugEnabled = false;
+try {
+  debugEnabled = localStorage.getItem("react-url-search-state:debug") !== null;
+} catch {}
 
-// Internal debug logger. helpful for dev.
+/**
+ * Enables or disables the internal debug logger at runtime.
+ *
+ * When enabled, navigation flushes and other internal events are logged to the console.
+ *
+ * @example
+ * import { setDebug } from "react-url-search-state";
+ * setDebug(true);
+ */
+export function setDebug(enabled: boolean) {
+  debugEnabled = enabled;
+}
+
+// Internal debug logger.
 export const debug = (message: string, ...args: any[]) => {
-  if (!DEBUG) return;
+  if (!debugEnabled) return;
   console.log(
     message,
     ...args.map((value) =>

--- a/packages/react-url-search-state/src/index.ts
+++ b/packages/react-url-search-state/src/index.ts
@@ -1,6 +1,7 @@
 export { SearchStateProvider } from "./context";
 export { createSearchUtils } from "./createSearchUtils";
 export { buildSearchString } from "./buildSearchString";
+export { setDebug } from "./debug";
 export {
   composeValidateSearch,
   defineValidateSearch,


### PR DESCRIPTION
## Summary

  - Replaces the frozen `DEBUG` IIFE constant in `debug.ts` with a module-level
    `let debugEnabled` variable, seeded from `localStorage` at import time
  - Adds a new public `setDebug(enabled: boolean)` export that updates the variable
    at runtime — no page reload required
  - Eliminates the per-call `localStorage.getItem` cost, making `debug()` safe to
    call in hot paths

  ## Test plan

  - [x] All 92 existing tests pass (`npm run test:run`)
  - [x] Manually verify: `import { setDebug } from "react-url-search-state"; setDebug(true)` produces console output on next navigation
  - [x] Manually verify: `setDebug(false)` silences output without a reload

Closes #27 