### PR TITLE
perf: replace redundant useMemo with useRef for context value

### DIFF
--- a/packages/react-url-search-state/src/context.ts
+++ b/packages/react-url-search-state/src/context.ts
@@ -3,7 +3,6 @@ import {
   createElement,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -56,10 +55,12 @@ function SearchStateProviderInner(props: {
   const [cache] = useState(() => new ValidatedSearchCache());
   const [navigationQueue] = useState(() => new NavigationQueue());
 
-  const value = useMemo(
-    () => ({ adapterRef, cache, navigationQueue, store }),
-    [adapterRef, cache, navigationQueue, store],
-  );
+  const valueRef = useRef<SearchStateContextValue>({
+    adapterRef,
+    cache,
+    navigationQueue,
+    store,
+  });
 
   useEffect(() => {
     store.setState(location.search);
@@ -71,7 +72,11 @@ function SearchStateProviderInner(props: {
     };
   }, [navigationQueue]);
 
-  return createElement(SearchStateContext.Provider, { value }, children);
+  return createElement(
+    SearchStateContext.Provider,
+    { value: valueRef.current },
+    children,
+  );
 }
 
 type SearchStateProviderProps = {


### PR DESCRIPTION
## Summary

  - `useMemo([adapterRef, cache, navigationQueue, store])` in `SearchStateProviderInner` ran exactly once because all deps are stable after mount; replaced with a
  plain `useRef` initialized at declaration
  - Removed the now-unused `useMemo` import from `context.ts`

  ## Why

  The `useMemo` pattern implies conditional memoization to readers, but the deps never change. A `useRef` accurately communicates "allocate once" intent.

  ## Test plan

  - [x] `npm run test:run` — 96/96 passing (no behavior change expected)

  Closes #<issue>

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #29 