### PR TITLE
fix: use nullish check for hash/pathname in `flushNavigate`

### DIFF
--- a/packages/react-url-search-state/src/useNavigate.ts
+++ b/packages/react-url-search-state/src/useNavigate.ts
@@ -38,8 +38,8 @@ export function flushNavigate(
   const nextSearch = stringifySearch(cleaned as AnySearch);
   if (
     nextSearch !== prevPath.search ||
-    (finalPath.pathname && finalPath.pathname !== prevPath.pathname) ||
-    (finalPath.hash && finalPath.hash !== prevPath.hash)
+    (finalPath.pathname != null && finalPath.pathname !== prevPath.pathname) ||
+    (finalPath.hash != null && finalPath.hash !== prevPath.hash)
   ) {
     const nextPath = { ...finalPath, search: nextSearch };
     debug(

--- a/packages/react-url-search-state/tests/useNavigate.test.tsx
+++ b/packages/react-url-search-state/tests/useNavigate.test.tsx
@@ -551,6 +551,33 @@ describe("useNavigate", () => {
     expect(pushSpy).not.toHaveBeenCalled();
   });
 
+  it("clears hash when navigating with hash: ''", () => {
+    const adapter = createTestAdapter("?page=1&tab=preview", "/stay", "#foo");
+    const spy = vi.spyOn(adapter, "pushState");
+
+    const NavigatorComponent = () => {
+      const navigate = useNavigate();
+
+      useEffect(() => {
+        navigate({
+          search: {},
+          hash: "",
+        });
+      }, []);
+
+      return null;
+    };
+
+    renderWithSearchProvider(<NavigatorComponent />, adapter);
+    vi.runAllTimers();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[1]).toMatchObject({
+      hash: "",
+      search: "?page=1&tab=preview",
+    });
+  });
+
   it("returns a stable function reference across re-renders", () => {
     const adapter = createTestAdapter();
     const navigateRefs: ReturnType<typeof useNavigate>[] = [];


### PR DESCRIPTION
## Summary

- Fixed `flushNavigate` dropping navigations when `hash` or `pathname` is an empty string, by replacing truthiness checks (`finalPath.hash &&`) with nullish checks (`finalPath.hash != null &&`)
- Added a test case that navigates with `hash: ""` from an initial `#foo` and verifies the navigation fires

## Test plan

- [x] New test: "clears hash when navigating with hash: ''" in `useNavigate.test.tsx`
- [x] All 97 tests pass

Closes #31