### PR TITLE
fix: skip emit in `SearchStore.setState` when state is structurally unchanged

### DIFF
--- a/packages/react-url-search-state/src/store.ts
+++ b/packages/react-url-search-state/src/store.ts
@@ -45,8 +45,10 @@ export class SearchStore {
     if (this.search === nextSearch) return;
     const nextState = replaceEqualDeep(this.state, parseSearch(nextSearch));
     this.search = nextSearch;
-    this.state = nextState;
-    this.emit();
+    if (nextState !== this.state) {
+      this.state = nextState;
+      this.emit();
+    }
   };
 
   /** Returns the current parsed search object. */

--- a/packages/react-url-search-state/tests/SearchStore.test.ts
+++ b/packages/react-url-search-state/tests/SearchStore.test.ts
@@ -36,6 +36,21 @@ describe("SearchStore", () => {
     expect(store.getState()).toEqual({ page: 2 });
   });
 
+  it("does not emit when param order changes but structure is the same", () => {
+    store.setState("?a=1&b=2");
+    const stateBefore = store.getState();
+    store.setState("?b=2&a=1"); // same structure, different string
+    expect(emitSpy).toHaveBeenCalledTimes(1); // no second emit
+    expect(store.getState()).toBe(stateBefore); // same reference
+  });
+
+  it("preserves state reference when structure is unchanged after reorder", () => {
+    store.setState("?x=hello&y=world");
+    const ref = store.getState();
+    store.setState("?y=world&x=hello");
+    expect(store.getState()).toBe(ref);
+  });
+
   it("unsubscribes correctly", () => {
     const unsubscribe = store.subscribe(emitSpy);
     unsubscribe();


### PR DESCRIPTION
## Summary

- Fixed `SearchStore.setState` emitting to subscribers when the search string changes but the parsed state is structurally identical (e.g. param reordering `?a=1&b=2` → `?b=2&a=1`)
- Gated both the state assignment and `emit()` on `nextState !== this.state`, so `replaceEqualDeep`'s referential equality guarantee is fully respected

## Test plan

- [x] New test: "does not emit when param order changes but structure is the same" in `SearchStore.test.ts`
- [x] New test: "preserves state reference when structure is unchanged after reorder" in `SearchStore.test.ts`
- [x] All 99 tests pass

Closes #33 