### PR TITLE
test: add `useSearchParamState` replace option coverage

### DIFF
--- a/packages/react-url-search-state/tests/useSearchParamState.test.tsx
+++ b/packages/react-url-search-state/tests/useSearchParamState.test.tsx
@@ -94,6 +94,53 @@ describe("useSearchParamState", () => {
     expect(adapter.location.search).toContain("page=5");
   });
   
+  it("uses replaceState when setter is called with replace: true", () => {
+    const adapter = createTestAdapter("?page=1&tab=preview");
+    const pushSpy = vi.spyOn(adapter, "pushState");
+    const replaceSpy = vi.spyOn(adapter, "replaceState");
+
+    const UpdateParam = () => {
+      const [page, setPage] = useSearchParamState("page");
+      useEffect(() => {
+        setPage(10, { replace: true });
+      }, []);
+      return <div data-testid="output">{String(page)}</div>;
+    };
+
+    const { rerender } = renderWithSearchProvider(<UpdateParam />, adapter);
+
+    vi.runAllTimers();
+    rerender(<UpdateParam />);
+
+    expect(screen.getByTestId("output").textContent).toBe("10");
+    expect(adapter.location.search).toContain("page=10");
+    expect(replaceSpy).toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses pushState by default (replace not set)", () => {
+    const adapter = createTestAdapter("?page=1&tab=preview");
+    const pushSpy = vi.spyOn(adapter, "pushState");
+    const replaceSpy = vi.spyOn(adapter, "replaceState");
+
+    const UpdateParam = () => {
+      const [page, setPage] = useSearchParamState("page");
+      useEffect(() => {
+        setPage(7);
+      }, []);
+      return <div data-testid="output">{String(page)}</div>;
+    };
+
+    const { rerender } = renderWithSearchProvider(<UpdateParam />, adapter);
+
+    vi.runAllTimers();
+    rerender(<UpdateParam />);
+
+    expect(screen.getByTestId("output").textContent).toBe("7");
+    expect(pushSpy).toHaveBeenCalled();
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
   it("clears param when set to undefined", async () => {
     const adapter = createTestAdapter("?page=3&tab=preview");
   


### PR DESCRIPTION
## Summary

- Add test verifying `setPage(10, { replace: true })` calls `replaceState` (not `pushState`)
- Add test verifying default setter (no options) calls `pushState` (not `replaceState`)

## Test plan

- [x] `npx vitest run packages/react-url-search-state/tests/useSearchParamState.test.tsx` — 7/7 pass
- [x] No existing tests broken

Closes #45 