### PR TITLE
fix: use deepEqual in stripSearchParams, add true/array input modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,19 +469,29 @@ const { useNavigate } = createSearchUtils(validateSearch, {
 });
 ```
 
-#### `stripSearchParams(defaults)`
+#### `stripSearchParams(input)`
 
-Removes search params that match their default values, keeping URLs clean. Params are compared with strict equality (`===`).
+Removes search params from the URL. Accepts three input modes:
 
 ```ts
 import { stripSearchParams } from "react-url-search-state";
 
+// 1. Strip by default value — removes params that deeply equal the provided defaults
 const { useNavigate } = createSearchUtils(validateSearch, {
   middleware: [stripSearchParams({ page: 1, sort: "asc" })],
 });
-
 // navigate({ search: { page: 1, sort: "asc", q: "foo" } })
 // URL becomes: ?q=foo (page and sort are stripped because they match defaults)
+
+// 2. Strip by key — removes listed keys unconditionally
+const { useNavigate } = createSearchUtils(validateSearch, {
+  middleware: [stripSearchParams(["page", "sort"])],
+});
+
+// 3. Strip all — removes all search params
+const { useNavigate } = createSearchUtils(validateSearch, {
+  middleware: [stripSearchParams(true)],
+});
 ```
 
 ### Interaction with `onBeforeNavigate`

--- a/packages/react-url-search-state/README.md
+++ b/packages/react-url-search-state/README.md
@@ -463,19 +463,29 @@ const { useNavigate } = createSearchUtils(validateSearch, {
 });
 ```
 
-#### `stripSearchParams(defaults)`
+#### `stripSearchParams(input)`
 
-Removes search params that match their default values, keeping URLs clean. Params are compared with strict equality (`===`).
+Removes search params from the URL. Accepts three input modes:
 
 ```ts
 import { stripSearchParams } from "react-url-search-state";
 
+// 1. Strip by default value — removes params that deeply equal the provided defaults
 const { useNavigate } = createSearchUtils(validateSearch, {
   middleware: [stripSearchParams({ page: 1, sort: "asc" })],
 });
-
 // navigate({ search: { page: 1, sort: "asc", q: "foo" } })
 // URL becomes: ?q=foo (page and sort are stripped because they match defaults)
+
+// 2. Strip by key — removes listed keys unconditionally
+const { useNavigate } = createSearchUtils(validateSearch, {
+  middleware: [stripSearchParams(["page", "sort"])],
+});
+
+// 3. Strip all — removes all search params
+const { useNavigate } = createSearchUtils(validateSearch, {
+  middleware: [stripSearchParams(true)],
+});
 ```
 
 ### Interaction with `onBeforeNavigate`

--- a/packages/react-url-search-state/src/index.ts
+++ b/packages/react-url-search-state/src/index.ts
@@ -25,6 +25,7 @@ export { useSetSearch } from "./useSetSearch";
 export type { SetSearchFunction } from "./useSetSearch";
 export { useSearchParamState } from "./useSearchParamState";
 export type { UseSearchParamStateReturn } from "./useSearchParamState";
+export { deepEqual } from "./utils";
 export {
   composeValidateSearch,
   defineValidateSearch,

--- a/packages/react-url-search-state/src/utils.ts
+++ b/packages/react-url-search-state/src/utils.ts
@@ -229,6 +229,63 @@ export function isPlainArray(value: unknown): value is Array<unknown> {
   return Array.isArray(value) && value.length === Object.keys(value).length;
 }
 
+// Copied from: https://github.com/TanStack/router/blob/main/packages/router-core/src/utils.ts
+export function deepEqual(
+  a: any,
+  b: any,
+  opts?: { partial?: boolean; ignoreUndefined?: boolean },
+): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0, l = a.length; i < l; i++) {
+      if (!deepEqual(a[i], b[i], opts)) return false;
+    }
+    return true;
+  }
+
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ignoreUndefined = opts?.ignoreUndefined ?? true;
+
+    if (opts?.partial) {
+      for (const k in b) {
+        if (!ignoreUndefined || b[k] !== undefined) {
+          if (!deepEqual(a[k], b[k], opts)) return false;
+        }
+      }
+      return true;
+    }
+
+    let aCount = 0;
+    if (!ignoreUndefined) {
+      aCount = Object.keys(a).length;
+    } else {
+      for (const k in a) {
+        if (a[k] !== undefined) aCount++;
+      }
+    }
+
+    let bCount = 0;
+    for (const k in b) {
+      if (!ignoreUndefined || b[k] !== undefined) {
+        bCount++;
+        if (bCount > aCount || !deepEqual(a[k], b[k], opts)) return false;
+      }
+    }
+
+    return aCount === bCount;
+  }
+
+  return false;
+}
+
 export function isEmptyObject(value: unknown): value is Record<string, never> {
   return typeof value === "object" && value !== null && Object.keys(value).length === 0;
 }


### PR DESCRIPTION
Closes #51

## Summary

- **Fix**: `stripSearchParams` now uses `deepEqual` (ported from TanStack Router) instead of `===`, fixing comparison of non-primitive values (objects, arrays) that go through JSON round-tripping
- **Feature**: `stripSearchParams` now accepts three input modes matching TanStack Router's API:
  - `Partial<TSearch>` — strips keys whose value deeply equals the provided default
  - `Array<keyof TSearch>` — strips listed keys unconditionally
  - `true` — strips all search params

## Changes

| File | Change |
|---|---|
| `src/utils.ts` | Add `deepEqual` (ported from TanStack Router) |
| `src/middleware.ts` | Use `deepEqual` in `stripSearchParams`, add `true` and array input modes |
| `src/index.ts` | Export `deepEqual` |
| `tests/middleware.test.ts` | 15 new tests: 8 for `deepEqual`, 3 for deep equality in strip, 4 for new input modes |
| `README.md` | Updated `stripSearchParams` docs with all three modes |
| `packages/.../README.md` | Same docs update |

## Test plan

- [x] `deepEqual` handles primitives, arrays, objects, nested structures, `ignoreUndefined`, `partial` mode
- [x] `stripSearchParams` strips non-primitive defaults (objects, arrays) via deep equality
- [x] `stripSearchParams(true)` strips all params while preserving path/options
- [x] `stripSearchParams(["key1", "key2"])` strips listed keys unconditionally
- [x] All 179 existing + new tests pass
- [x] TypeScript compiles cleanly (`tsc -b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>