### PR TITLE
chore(release): react-url-search-state 0.1.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.1.0-alpha.6] — 2026-06-25
+
+### Breaking Changes
+
+- **Adapter interface changed from a render-prop component to a hook.** The `SearchStateProvider` `adapter` prop now expects a hook (`() => SearchStateAdapter`) instead of a render-prop component. This removes an intermediate adapter component render on every URL change.
+  - The four official adapters renamed their exports accordingly:
+    - `ReactRouterDomV5Adapter` → `useReactRouterDomV5Adapter`
+    - `ReactRouterDomV6Adapter` → `useReactRouterDomV6Adapter`
+    - `ReactRouterDomV7Adapter` → `useReactRouterDomV7Adapter`
+    - `WouterV3Adapter` → `useWouterV3Adapter`
+  - `SearchStateAdapterComponent` is now **deprecated** (still exported, removed in 1.0). Use the new `SearchStateAdapterHook` type.
+
+  **Migration:**
+
+  ```diff
+  - import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+  + import { useReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+
+  - <SearchStateProvider adapter={ReactRouterDomV6Adapter}>
+  + <SearchStateProvider adapter={useReactRouterDomV6Adapter}>
+  ```
+
+  If you wrote a custom adapter, convert the component to a hook that returns the `SearchStateAdapter` object directly (call `useLocation`/`useNavigate` inside and return `{ location, pushState, replaceState }`) instead of passing it through a `children` render prop.
+
+### Added
+
+- **Custom search param serialization.** `SearchStateProvider` now accepts optional `parseSearch` and `stringifySearch` props to override the default JSON-ish (de)serialization. New `parseSearchWith` / `stringifySearchWith` helpers are exported for building custom (de)serializers.
+- New `SearchStateAdapterHook` type export (`() => SearchStateAdapter`).
+
+### Fixed
+
+- **Stale search value during route transitions.** The provider now syncs the store with the URL **during render** (render-phase `updateState` + a layout-effect `emit`) instead of in a `useEffect`. This eliminates the one-render window where `useSearch`/`getSnapshot()` could return the *previous* route's search value immediately after navigating. Consumers no longer need "wait a tick" workarounds.
+- `useNavigate` reads the context via a ref inside its callback, avoiding capturing a stale context from the first render.
+
+### Changed
+
+- `cleanSearchObject` is no longer called from `flushNavigate` / `buildSearchString`. Top-level `undefined` values are still stripped during serialization (via `stringifySearchWith`); **nested `undefined` values inside objects are no longer removed** before serialization. (No public API change.)
+
+### Performance
+
+- `flushNavigate` reduces redundant validator calls from N+1 to 2 per flush.
+
+### Adapters
+
+- **Fixed adapter packaging for publishing.** The adapter packages previously declared `react`, the router library, and `react-url-search-state` as regular `dependencies` — including an unresolvable `"react-url-search-state": "file:../…"` reference that made the published packages uninstallable. These are now correctly declared as `peerDependencies` (the adapter must share the host app's single instance of React, the router, and the search-state context); build-time copies are kept in `devDependencies` using the published semver range (no `file:` references remain anywhere in the manifests).
+  - `react-url-search-state-adapter-react-router-dom-v6` → **0.1.0-alpha.1** (republish required to expose `useReactRouterDomV6Adapter` and the corrected peer deps)
+  - `react-url-search-state-adapter-wouter-v3` → **0.1.0-alpha.2** (`alpha.1` was already published with the old packaging)
+  - `…-react-router-dom-v5` / `…-v7` ship at `0.1.0-alpha.0` (first publish, with the corrected packaging)
+- **Fixed the v5 adapter build.** `react-router-dom@5` ships its types via `@types/react-router-dom`, but npm hoists `react-router-dom@6` (whose bundled types lack `useHistory`) to the workspace root, shadowing them. A build-time `paths` mapping in the v5 adapter's `tsconfig.json` points type resolution at `@types/react-router-dom`. (Emit is unaffected — the published `.d.ts` still imports from `react-router-dom`.)
+
+### Publishing
+
+- Each publishable package now has a `prepack` script that runs its build, so `npm publish` / `npm pack` always ships a freshly built `dist` (previously there was no pre-publish build hook, so a stale or missing `dist` could be published silently).
+
+---
+
 ## [0.1.0-alpha.5] — 2026-02-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ The `SearchStateProvider` connects the core library to your router via an adapte
 ```tsx
 // main.tsx
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+import { useReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
 
 function Root() {
   return (
-    <SearchStateProvider adapter={ReactRouterDomV6Adapter}>
+    <SearchStateProvider adapter={useReactRouterDomV6Adapter}>
       <App />
     </SearchStateProvider>
   );
@@ -292,9 +292,9 @@ Context provider that connects the core library to your router.
 
 ```tsx
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+import { useReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
 
-<SearchStateProvider adapter={ReactRouterDomV6Adapter}>
+<SearchStateProvider adapter={useReactRouterDomV6Adapter}>
   {children}
 </SearchStateProvider>
 ```
@@ -303,8 +303,10 @@ import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-ro
 
 | Prop | Type | Description |
 |---|---|---|
-| `adapter` | `SearchStateAdapterComponent` | A router adapter component. See [Adapters](#adapters). |
+| `adapter` | `SearchStateAdapterHook` | A router adapter hook (`() => SearchStateAdapter`). See [Adapters](#adapters). |
 | `middleware` | `SearchMiddleware[]` | Provider-level middleware applied to all navigations. See [Middleware](#middleware). |
+| `parseSearch` | `(searchStr: string) => Record<string, unknown>` | Optional. Override the default search-string parser. |
+| `stringifySearch` | `(search: Record<string, unknown>) => string` | Optional. Override the default search serializer. |
 
 ---
 
@@ -347,7 +349,7 @@ Error thrown when a `validateSearch` function fails. Caught internally and re-th
 
 ## Adapters
 
-Adapters are thin components that bridge router-specific APIs (`useLocation`, `useNavigate`) into a uniform `SearchStateAdapter` interface. The core library never imports any router directly.
+Adapters are thin hooks that bridge router-specific APIs (`useLocation`, `useNavigate`) into a uniform `SearchStateAdapter` interface. The core library never imports any router directly.
 
 | Adapter | Package | Install |
 |---|---|---|
@@ -358,18 +360,18 @@ Adapters are thin components that bridge router-specific APIs (`useLocation`, `u
 
 ### Writing a custom adapter
 
-An adapter is a React component that calls `children` with a `SearchStateAdapter` object:
+An adapter is a React hook that returns a `SearchStateAdapter` object:
 
 ```tsx
-import type { SearchStateAdapterComponent } from "react-url-search-state";
+import type { SearchStateAdapterHook } from "react-url-search-state";
 
-const MyAdapter: SearchStateAdapterComponent = ({ children }) => {
+const useMyAdapter: SearchStateAdapterHook = () => {
   // Hook into your router's location and navigation APIs
   const location = { pathname: "/", search: "", hash: "" };
   const pushState = (state: any, path) => { /* ... */ };
   const replaceState = (state: any, path) => { /* ... */ };
 
-  return children({ location, pushState, replaceState });
+  return { location, pushState, replaceState };
 };
 ```
 
@@ -404,7 +406,7 @@ Middleware composes at three levels, executed outermost to innermost:
 
 ```ts
 // Provider-level (untyped, applies to all navigations)
-<SearchStateProvider adapter={Adapter} middleware={[providerMiddleware]}>
+<SearchStateProvider adapter={useAdapter} middleware={[providerMiddleware]}>
 
 // Factory-level (typed to your validator)
 const { useNavigate } = createSearchUtils(validateSearch, {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,152 @@
+# Releasing
+
+This document is the exact command sequence for cutting a release of
+`react-url-search-state` and its adapters to npm.
+
+> **Current target:** `0.1.0-alpha.6` (core) + adapter bumps. Replace versions
+> below if you are cutting a later release.
+
+---
+
+## 0. Prerequisites (once)
+
+```bash
+# Authenticated as a user with publish rights to the packages
+npm whoami            # should print your npm username
+npm login             # if the above fails
+
+# Clean tree on the release branch, fully reviewed and merged to main
+git checkout main
+git pull
+git status            # must be clean
+```
+
+> **Note on the release branch.** The `release/0.1.0-alpha.6` branch was squashed
+> and rewritten locally after it had already been pushed to `origin`. If you push
+> that branch again before merging you will need:
+>
+> ```bash
+> git push --force-with-lease origin release/0.1.0-alpha.6
+> ```
+>
+> Publishing itself should happen from `main` after the branch is merged.
+
+---
+
+## 1. Pre-flight verification (no publish)
+
+Run from the repo root.
+
+```bash
+# Full clean build of every package (skips workspaces without a build script)
+npm run build --ws --if-present
+
+# Full test suite (single pass)
+npm run test:run
+
+# Confirm the target versions are still free on npm
+npm view react-url-search-state@0.1.0-alpha.6 version || echo "free ✓"
+npm view react-url-search-state-adapter-react-router-dom-v5@0.1.0-alpha.0 version || echo "free ✓"
+npm view react-url-search-state-adapter-react-router-dom-v6@0.1.0-alpha.1 version || echo "free ✓"
+npm view react-url-search-state-adapter-react-router-dom-v7@0.1.0-alpha.0 version || echo "free ✓"
+npm view react-url-search-state-adapter-wouter-v3@0.1.0-alpha.2 version || echo "free ✓"
+```
+
+### Dry-run the tarballs
+
+Each package has a `prepack` hook that runs `npm run build`, so `npm pack`
+produces exactly what `npm publish` would ship. Inspect contents before publishing:
+
+```bash
+npm pack --dry-run -w react-url-search-state
+npm pack --dry-run -w react-url-search-state-adapter-react-router-dom-v5
+npm pack --dry-run -w react-url-search-state-adapter-react-router-dom-v6
+npm pack --dry-run -w react-url-search-state-adapter-react-router-dom-v7
+npm pack --dry-run -w react-url-search-state-adapter-wouter-v3
+```
+
+Confirm each tarball includes `dist/esm`, `dist/cjs`, co-located `.d.ts`, and
+`src`, with `peerDependencies` (not `dependencies`) and **no `file:` references**.
+
+---
+
+## 2. Publish (order matters)
+
+Publish the **core first** — the adapters declare it as a peerDependency, but
+publishing core first keeps the registry consistent for anyone installing the
+adapters immediately after.
+
+All packages carry `publishConfig: { "access": "public", "tag": "alpha" }`, so
+they publish to the **`alpha`** dist-tag (not `latest`) automatically. The
+`prepack` hook rebuilds `dist` on each publish.
+
+```bash
+# 1) Core
+npm publish -w react-url-search-state
+
+# 2) Adapters (any order among themselves)
+npm publish -w react-url-search-state-adapter-react-router-dom-v5
+npm publish -w react-url-search-state-adapter-react-router-dom-v6
+npm publish -w react-url-search-state-adapter-react-router-dom-v7
+npm publish -w react-url-search-state-adapter-wouter-v3
+```
+
+If a publish fails midway, fix the issue and re-run only the failed package —
+already-published versions are immutable and cannot be re-published.
+
+---
+
+## 3. Post-publish verification
+
+```bash
+# Confirm each version is live on the alpha tag
+npm view react-url-search-state dist-tags
+npm view react-url-search-state-adapter-react-router-dom-v5 dist-tags
+npm view react-url-search-state-adapter-react-router-dom-v6 dist-tags
+npm view react-url-search-state-adapter-react-router-dom-v7 dist-tags
+npm view react-url-search-state-adapter-wouter-v3 dist-tags
+
+# Smoke-install into a throwaway dir
+cd "$(mktemp -d)"
+npm init -y >/dev/null
+npm i react-url-search-state@alpha react-url-search-state-adapter-react-router-dom-v6@alpha
+```
+
+---
+
+## 4. `latest` dist-tag (decide explicitly)
+
+⚠️ The `latest` tag is currently **stale** — it points at an old prerelease
+(`0.1.0-alpha.1`), so a plain `npm install react-url-search-state` does **not**
+get this release. While still in alpha this is arguably correct (you don't want
+`latest` resolving to a prerelease). If you *do* want `latest` to track the
+newest alpha, move it manually after publishing:
+
+```bash
+npm dist-tag add react-url-search-state@0.1.0-alpha.6 latest
+# (repeat per package if desired)
+```
+
+This is a registry operation, not a code change — make it only when you
+intend `npm install <pkg>` (no tag) to resolve to this release.
+
+---
+
+## 5. Tag the release in git
+
+```bash
+git tag react-url-search-state@0.1.0-alpha.6
+git push origin react-url-search-state@0.1.0-alpha.6
+```
+
+---
+
+## Package / version reference
+
+| Package | This release | Tag |
+| --- | --- | --- |
+| `react-url-search-state` | `0.1.0-alpha.6` | `alpha` |
+| `react-url-search-state-adapter-react-router-dom-v5` | `0.1.0-alpha.0` | `alpha` |
+| `react-url-search-state-adapter-react-router-dom-v6` | `0.1.0-alpha.1` | `alpha` |
+| `react-url-search-state-adapter-react-router-dom-v7` | `0.1.0-alpha.0` | `alpha` |
+| `react-url-search-state-adapter-wouter-v3` | `0.1.0-alpha.2` | `alpha` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -955,6 +956,7 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
       "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -2528,6 +2530,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       }
@@ -3690,6 +3693,7 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
       "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
@@ -3703,6 +3707,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -3710,7 +3715,8 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -4240,7 +4246,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4441,6 +4448,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -4538,6 +4546,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly": {
@@ -4625,6 +4634,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4844,6 +4854,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
       "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -4851,7 +4862,8 @@
     "node_modules/path-to-regexp/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4991,6 +5003,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5000,7 +5013,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5060,6 +5074,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
@@ -5088,6 +5103,7 @@
       "version": "6.30.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
       "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.0"
@@ -5103,6 +5119,7 @@
       "version": "6.30.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
       "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.0",
@@ -5195,6 +5212,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
       "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5239,7 +5257,8 @@
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "dev": true
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -5399,6 +5418,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "dev": true,
       "peer": true
     },
     "node_modules/semver": {
@@ -5413,7 +5433,8 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5771,12 +5792,14 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -6130,6 +6153,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6138,7 +6162,8 @@
     "node_modules/value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "6.3.5",
@@ -6563,6 +6588,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.7.1.tgz",
       "integrity": "sha512-od5LGmndSUzntZkE2R5CHhoiJ7YMuTIbiXsa0Anytc2RATekgv4sfWRAxLEULBrp7ADzinWQw8g470lkT8+fOw==",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -6628,11 +6654,8 @@
       }
     },
     "packages/react-url-search-state": {
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.6",
       "license": "MIT",
-      "dependencies": {
-        "react": "^19.1.0"
-      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -6649,20 +6672,19 @@
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "prettier": "3.5.3",
+        "react": "^19.1.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
         "vitest": "^3.1.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "packages/react-url-search-state-adapter-react-router-dom-v5": {
       "version": "0.1.0-alpha.0",
       "license": "MIT",
-      "dependencies": {
-        "react": "^19.1.0",
-        "react-router-dom": "^5.3.4",
-        "react-url-search-state": "file:../react-url-search-state"
-      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -6680,22 +6702,32 @@
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "prettier": "3.5.3",
+        "react": "^19.1.0",
+        "react-router-dom": "^5.3.4",
+        "react-url-search-state": "^0.1.0-alpha.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.1.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-router-dom": "^5.3.4",
+        "react-url-search-state": "^0.1.0-alpha.6"
       }
     },
     "packages/react-url-search-state-adapter-react-router-dom-v5/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "packages/react-url-search-state-adapter-react-router-dom-v5/node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -6715,6 +6747,7 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
       "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -6729,13 +6762,8 @@
       }
     },
     "packages/react-url-search-state-adapter-react-router-dom-v6": {
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.0-alpha.1",
       "license": "MIT",
-      "dependencies": {
-        "react": "^19.1.0",
-        "react-router-dom": "^6.30.1",
-        "react-url-search-state": "file:../react-url-search-state"
-      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -6752,21 +6780,24 @@
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "prettier": "3.5.3",
+        "react": "^19.1.0",
+        "react-router-dom": "^6.30.1",
+        "react-url-search-state": "^0.1.0-alpha.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.1.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-router-dom": "^6.30.1",
+        "react-url-search-state": "^0.1.0-alpha.6"
       }
     },
     "packages/react-url-search-state-adapter-react-router-dom-v7": {
       "version": "0.1.0-alpha.0",
       "license": "MIT",
-      "dependencies": {
-        "react": "^19.1.0",
-        "react-router-dom": "^7.6.2",
-        "react-url-search-state": "file:../react-url-search-state"
-      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -6783,17 +6814,26 @@
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "prettier": "3.5.3",
+        "react": "^19.1.0",
+        "react-router-dom": "^7.6.2",
+        "react-url-search-state": "^0.1.0-alpha.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.1.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-router-dom": "^7.6.2",
+        "react-url-search-state": "^0.1.0-alpha.6"
       }
     },
     "packages/react-url-search-state-adapter-react-router-dom-v7/node_modules/react-router": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
       "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "dev": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -6815,6 +6855,7 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
       "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "dev": true,
       "dependencies": {
         "react-router": "7.6.2"
       },
@@ -6827,13 +6868,8 @@
       }
     },
     "packages/react-url-search-state-adapter-wouter-v3": {
-      "version": "0.1.0-alpha.1",
+      "version": "0.1.0-alpha.2",
       "license": "MIT",
-      "dependencies": {
-        "react": "^19.1.0",
-        "react-url-search-state": "file:../react-url-search-state",
-        "wouter": "^3.7.1"
-      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -6850,10 +6886,18 @@
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "prettier": "3.5.3",
+        "react": "^19.1.0",
+        "react-url-search-state": "^0.1.0-alpha.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
-        "vitest": "^3.1.4"
+        "vitest": "^3.1.4",
+        "wouter": "^3.7.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-url-search-state": "^0.1.0-alpha.6",
+        "wouter": "^3.7.1"
       }
     }
   }

--- a/packages/react-url-search-state-adapter-react-router-dom-v5/README.md
+++ b/packages/react-url-search-state-adapter-react-router-dom-v5/README.md
@@ -17,12 +17,12 @@ Wrap your app with `SearchStateProvider` inside a `<Router>`:
 ```tsx
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV5Adapter } from "react-url-search-state-adapter-react-router-dom-v5";
+import { useReactRouterDomV5Adapter } from "react-url-search-state-adapter-react-router-dom-v5";
 
 function App() {
   return (
     <BrowserRouter>
-      <SearchStateProvider adapter={ReactRouterDomV5Adapter}>
+      <SearchStateProvider adapter={useReactRouterDomV5Adapter}>
         <Switch>
           <Route path="/" component={Home} />
         </Switch>

--- a/packages/react-url-search-state-adapter-react-router-dom-v5/package.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v5/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "clean": "rm -rf dist",
+    "prepack": "npm run build",
     "lint": "eslint .",
     "test": "vitest",
     "test:run": "vitest run",
@@ -37,12 +38,15 @@
     "access": "public",
     "tag": "alpha"
   },
-  "dependencies": {
-    "react": "^19.1.0",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
     "react-router-dom": "^5.3.4",
-    "react-url-search-state": "file:../react-url-search-state"
+    "react-url-search-state": "^0.1.0-alpha.6"
   },
   "devDependencies": {
+    "react": "^19.1.0",
+    "react-router-dom": "^5.3.4",
+    "react-url-search-state": "^0.1.0-alpha.6",
     "@eslint/js": "^9.25.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/react-url-search-state-adapter-react-router-dom-v5/tsconfig.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v5/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "*": ["src/*"]
+      "*": ["src/*"],
+      "react-router-dom": ["../../node_modules/@types/react-router-dom"]
     }
   },
   "include": ["src", "tests", "vite.config.ts"]

--- a/packages/react-url-search-state-adapter-react-router-dom-v6/README.md
+++ b/packages/react-url-search-state-adapter-react-router-dom-v6/README.md
@@ -17,11 +17,11 @@ Wrap your app with `SearchStateProvider` inside a route tree:
 ```tsx
 import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+import { useReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
 
 function Root() {
   return (
-    <SearchStateProvider adapter={ReactRouterDomV6Adapter}>
+    <SearchStateProvider adapter={useReactRouterDomV6Adapter}>
       <Outlet />
     </SearchStateProvider>
   );

--- a/packages/react-url-search-state-adapter-react-router-dom-v6/package.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v6/package.json
@@ -2,7 +2,7 @@
   "name": "react-url-search-state-adapter-react-router-dom-v6",
   "description": "react-router-dom@6 adapter for react-url-search-state",
   "private": false,
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "clean": "rm -rf dist",
+    "prepack": "npm run build",
     "lint": "eslint .",
     "test": "vitest",
     "test:run": "vitest run",
@@ -37,12 +38,15 @@
     "access": "public",
     "tag": "alpha"
   },
-  "dependencies": {
-    "react": "^19.1.0",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
     "react-router-dom": "^6.30.1",
-    "react-url-search-state": "file:../react-url-search-state"
+    "react-url-search-state": "^0.1.0-alpha.6"
   },
   "devDependencies": {
+    "react": "^19.1.0",
+    "react-router-dom": "^6.30.1",
+    "react-url-search-state": "^0.1.0-alpha.6",
     "@eslint/js": "^9.25.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/react-url-search-state-adapter-react-router-dom-v7/README.md
+++ b/packages/react-url-search-state-adapter-react-router-dom-v7/README.md
@@ -17,11 +17,11 @@ Wrap your app with `SearchStateProvider` inside a route tree:
 ```tsx
 import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV7Adapter } from "react-url-search-state-adapter-react-router-dom-v7";
+import { useReactRouterDomV7Adapter } from "react-url-search-state-adapter-react-router-dom-v7";
 
 function Root() {
   return (
-    <SearchStateProvider adapter={ReactRouterDomV7Adapter}>
+    <SearchStateProvider adapter={useReactRouterDomV7Adapter}>
       <Outlet />
     </SearchStateProvider>
   );

--- a/packages/react-url-search-state-adapter-react-router-dom-v7/package.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v7/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "clean": "rm -rf dist",
+    "prepack": "npm run build",
     "lint": "eslint .",
     "test": "vitest",
     "test:run": "vitest run",
@@ -37,12 +38,15 @@
     "access": "public",
     "tag": "alpha"
   },
-  "dependencies": {
-    "react": "^19.1.0",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
     "react-router-dom": "^7.6.2",
-    "react-url-search-state": "file:../react-url-search-state"
+    "react-url-search-state": "^0.1.0-alpha.6"
   },
   "devDependencies": {
+    "react": "^19.1.0",
+    "react-router-dom": "^7.6.2",
+    "react-url-search-state": "^0.1.0-alpha.6",
     "@eslint/js": "^9.25.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/react-url-search-state-adapter-wouter-v3/README.md
+++ b/packages/react-url-search-state-adapter-wouter-v3/README.md
@@ -16,11 +16,11 @@ Wrap your app with `SearchStateProvider`:
 
 ```tsx
 import { SearchStateProvider } from "react-url-search-state";
-import { WouterV3Adapter } from "react-url-search-state-adapter-wouter-v3";
+import { useWouterV3Adapter } from "react-url-search-state-adapter-wouter-v3";
 
 function App() {
   return (
-    <SearchStateProvider adapter={WouterV3Adapter}>
+    <SearchStateProvider adapter={useWouterV3Adapter}>
       <Home />
     </SearchStateProvider>
   );

--- a/packages/react-url-search-state-adapter-wouter-v3/package.json
+++ b/packages/react-url-search-state-adapter-wouter-v3/package.json
@@ -2,7 +2,7 @@
   "name": "react-url-search-state-adapter-wouter-v3",
   "description": "wouter@3 adapter for react-url-search-state",
   "private": false,
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "clean": "rm -rf dist",
+    "prepack": "npm run build",
     "lint": "eslint .",
     "test": "vitest",
     "test:run": "vitest run",
@@ -37,12 +38,15 @@
     "access": "public",
     "tag": "alpha"
   },
-  "dependencies": {
-    "react": "^19.1.0",
-    "react-url-search-state": "file:../react-url-search-state",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-url-search-state": "^0.1.0-alpha.6",
     "wouter": "^3.7.1"
   },
   "devDependencies": {
+    "react": "^19.1.0",
+    "react-url-search-state": "^0.1.0-alpha.6",
+    "wouter": "^3.7.1",
     "@eslint/js": "^9.25.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/react-url-search-state/README.md
+++ b/packages/react-url-search-state/README.md
@@ -82,11 +82,11 @@ The `SearchStateProvider` connects the core library to your router via an adapte
 ```tsx
 // main.tsx
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+import { useReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
 
 function Root() {
   return (
-    <SearchStateProvider adapter={ReactRouterDomV6Adapter}>
+    <SearchStateProvider adapter={useReactRouterDomV6Adapter}>
       <App />
     </SearchStateProvider>
   );
@@ -282,9 +282,9 @@ Context provider that connects the core library to your router.
 
 ```tsx
 import { SearchStateProvider } from "react-url-search-state";
-import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
+import { useReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-router-dom-v6";
 
-<SearchStateProvider adapter={ReactRouterDomV6Adapter}>
+<SearchStateProvider adapter={useReactRouterDomV6Adapter}>
   {children}
 </SearchStateProvider>
 ```
@@ -293,8 +293,10 @@ import { ReactRouterDomV6Adapter } from "react-url-search-state-adapter-react-ro
 
 | Prop | Type | Description |
 |---|---|---|
-| `adapter` | `SearchStateAdapterComponent` | A router adapter component. See [Adapters](#adapters). |
+| `adapter` | `SearchStateAdapterHook` | A router adapter hook (`() => SearchStateAdapter`). See [Adapters](#adapters). |
 | `middleware` | `SearchMiddleware[]` | Provider-level middleware applied to all navigations. See [Middleware](#middleware). |
+| `parseSearch` | `(searchStr: string) => Record<string, unknown>` | Optional. Override the default search-string parser. |
+| `stringifySearch` | `(search: Record<string, unknown>) => string` | Optional. Override the default search serializer. |
 
 ---
 
@@ -341,7 +343,7 @@ This only occurs if your validator actually throws — if your validator silentl
 
 ## Adapters
 
-Adapters are thin components that bridge router-specific APIs (`useLocation`, `useNavigate`) into a uniform `SearchStateAdapter` interface. The core library never imports any router directly.
+Adapters are thin hooks that bridge router-specific APIs (`useLocation`, `useNavigate`) into a uniform `SearchStateAdapter` interface. The core library never imports any router directly.
 
 | Adapter | Package | Install |
 |---|---|---|
@@ -352,18 +354,18 @@ Adapters are thin components that bridge router-specific APIs (`useLocation`, `u
 
 ### Writing a custom adapter
 
-An adapter is a React component that calls `children` with a `SearchStateAdapter` object:
+An adapter is a React hook that returns a `SearchStateAdapter` object:
 
 ```tsx
-import type { SearchStateAdapterComponent } from "react-url-search-state";
+import type { SearchStateAdapterHook } from "react-url-search-state";
 
-const MyAdapter: SearchStateAdapterComponent = ({ children }) => {
+const useMyAdapter: SearchStateAdapterHook = () => {
   // Hook into your router's location and navigation APIs
   const location = { pathname: "/", search: "", hash: "" };
   const pushState = (state: any, path) => { /* ... */ };
   const replaceState = (state: any, path) => { /* ... */ };
 
-  return children({ location, pushState, replaceState });
+  return { location, pushState, replaceState };
 };
 ```
 
@@ -398,7 +400,7 @@ Middleware composes at three levels, executed outermost to innermost:
 
 ```ts
 // Provider-level (untyped, applies to all navigations)
-<SearchStateProvider adapter={Adapter} middleware={[providerMiddleware]}>
+<SearchStateProvider adapter={useAdapter} middleware={[providerMiddleware]}>
 
 // Factory-level (typed to your validator)
 const { useNavigate } = createSearchUtils(validateSearch, {

--- a/packages/react-url-search-state/package.json
+++ b/packages/react-url-search-state/package.json
@@ -2,7 +2,7 @@
   "name": "react-url-search-state",
   "description": "Typed URL search param state for React, with JSON parsing and no router lock-in.",
   "private": false,
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "clean": "rm -rf dist",
+    "prepack": "npm run build",
     "lint": "eslint .",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
## Summary

- **Breaking:** Adapter interface changed from a render-prop component to a hook (`SearchStateAdapterHook`). All four official adapters renamed from `FooAdapter` → `useFooAdapter`. Migration diff included in CHANGELOG.
- **Fixed:** Stale search value during route transitions — provider now syncs the store during render (render-phase `updateState` + layout-effect `emit`) instead of in a `useEffect`, eliminating the one-render window where `useSearch` could return the previous route's search.
- **Fixed adapter packaging:** Adapter packages previously declared `react`, the router library, and `react-url-search-state` as regular `dependencies` (including an unresolvable `file:` reference) — now correctly `peerDependencies`. This makes all adapter packages installable for the first time.
- **Fixed v5 adapter build:** npm 11 ignores `nohoist` (Yarn-only), causing `react-router-dom@6` bundled types to shadow `@types/react-router-dom`. Fixed via a build-time `paths` mapping in the v5 `tsconfig.json`.
- **Added `prepack` hook** on all five packages — `npm publish` / `npm pack` now always ships a freshly built `dist`.
- **Added `RELEASING.md`** — exact publish command sequence for future releases.
- **Added:** Custom search param serialization via `parseSearch` / `stringifySearch` props on `SearchStateProvider`, plus `parseSearchWith` / `stringifySearchWith` helpers.
- **Adapter version bumps:** `v6` → `0.1.0-alpha.1`, `wouter-v3` → `0.1.0-alpha.2` (collision with old publish), `v5` + `v7` at `0.1.0-alpha.0` (first publish).

## Test plan

- [x] 198/198 tests pass (`npm run test:run` from repo root)
- [x] All 5 packages build clean (`npm run build --ws --if-present`)
- [x] All target versions confirmed free on npm before publishing
- [x] `npm pack --dry-run` per package confirms tarballs contain `dist/esm`, `dist/cjs`, `.d.ts`, correct `peerDependencies`, no `file:` references
- [ ] Post-publish: `npm view <pkg> dist-tags` confirms `alpha` tag points at new versions
- [ ] Smoke-install: `npm i react-url-search-state@alpha react-url-search-state-adapter-react-router-dom-v6@alpha` in a fresh dir
- [ ] Decide whether to move `latest` dist-tag (currently stale at `0.1.0-alpha.1`) — see `RELEASING.md §4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
