### PR TITLE
chore: add repository field to all published package.json files

### DIFF
--- a/packages/react-url-search-state-adapter-react-router-dom-v5/package.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v5/package.json
@@ -34,6 +34,11 @@
     "src"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dennisduong/react-url-search-state",
+    "directory": "packages/react-url-search-state-adapter-react-router-dom-v5"
+  },
   "publishConfig": {
     "access": "public",
     "tag": "alpha"

--- a/packages/react-url-search-state-adapter-react-router-dom-v6/package.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v6/package.json
@@ -34,6 +34,11 @@
     "src"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dennisduong/react-url-search-state",
+    "directory": "packages/react-url-search-state-adapter-react-router-dom-v6"
+  },
   "publishConfig": {
     "access": "public",
     "tag": "alpha"

--- a/packages/react-url-search-state-adapter-react-router-dom-v7/package.json
+++ b/packages/react-url-search-state-adapter-react-router-dom-v7/package.json
@@ -34,6 +34,11 @@
     "src"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dennisduong/react-url-search-state",
+    "directory": "packages/react-url-search-state-adapter-react-router-dom-v7"
+  },
   "publishConfig": {
     "access": "public",
     "tag": "alpha"

--- a/packages/react-url-search-state-adapter-wouter-v3/package.json
+++ b/packages/react-url-search-state-adapter-wouter-v3/package.json
@@ -34,6 +34,11 @@
     "src"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dennisduong/react-url-search-state",
+    "directory": "packages/react-url-search-state-adapter-wouter-v3"
+  },
   "publishConfig": {
     "access": "public",
     "tag": "alpha"

--- a/packages/react-url-search-state/package.json
+++ b/packages/react-url-search-state/package.json
@@ -34,6 +34,11 @@
     "src"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dennisduong/react-url-search-state",
+    "directory": "packages/react-url-search-state"
+  },
   "publishConfig": {
     "access": "public",
     "tag": "alpha"


### PR DESCRIPTION
Adds the `repository` field to all five published packages so that the
NPM registry page for each package links back to the GitHub repository.

The `directory` sub-field is included on each entry to point NPM at the
correct subfolder within the monorepo.

### Packages updated

- `packages/react-url-search-state`
- `packages/react-url-search-state-adapter-react-router-dom-v5`
- `packages/react-url-search-state-adapter-react-router-dom-v6`
- `packages/react-url-search-state-adapter-react-router-dom-v7`
- `packages/react-url-search-state-adapter-wouter-v3`

---

## Checklist before opening
- [ ] Commit the five changed `package.json` files on `chore/add-repository-field`
- [ ] Push the branch: `git push -u origin chore/add-repository-field`
- [ ] Open PR on GitHub: base `main` ← compare `chore/add-repository-field`
- [ ] Paste the title and description above