### PR TITLE
feat: make core SSR-safe with isomorphic layout effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,40 @@ const hooks = createSearchUtils(validateSearch, {
 
 ---
 
+## Server-Side Rendering
+
+Search-param state is uniquely well-suited to SSR: it lives in the request URL, which the server already has synchronously — before the first byte is sent. There's nothing to fetch, await, or reconcile after hydration.
+
+Because the same URL flows through the same pure `validateSearch` function on both the server and the client, both produce an identical validated object. That's the whole hydration contract, and it's satisfied by design:
+
+- **No flash of default state** — defaults for missing params are applied during the first (server) render, not in a post-hydration effect. Filters, pagination, and tabs render correctly on first paint.
+- **No hydration mismatches** — server and client initialize the store from the same URL and validate it the same way, so the first client render matches the server HTML.
+- **SEO-friendly** — search-param-driven content is fully present in the server-rendered HTML.
+
+The core library is SSR-safe: it never reads `window`, `document`, or `localStorage` during render or at module load, and browser-only effects degrade gracefully on the server.
+
+### The adapter supplies the URL
+
+Whether the server knows the request URL is a router/framework concern, which is exactly what the [adapter](#adapters) abstracts. As long as your adapter provides `location.search` on the server — which framework routers do during their server render — the core renders correctly there with no SSR-specific configuration.
+
+```tsx
+// A static, hook-shaped adapter for a known request URL (e.g. built from req.url).
+// Navigation is a no-op because there is nowhere to navigate to on the server.
+import type { SearchStateAdapter } from "react-url-search-state";
+
+function createStaticAdapter(search: string): SearchStateAdapter {
+  return {
+    location: { pathname: "/", search, hash: "" },
+    pushState: () => {},
+    replaceState: () => {},
+  };
+}
+```
+
+> **Note:** `hash` is not available on the server in some frameworks (e.g. Next.js App Router), so hash-driven state can't participate in SSR there. Search and pathname are unaffected.
+
+---
+
 ## Why This Library?
 
 Inspired by [TanStack Router](https://tanstack.com/router)'s philosophy of treating search params as typed state, and the adapter pattern of [use-query-params](https://github.com/pbeshai/use-query-params), this library aims to:

--- a/packages/react-url-search-state/src/context.ts
+++ b/packages/react-url-search-state/src/context.ts
@@ -2,11 +2,11 @@ import {
   createContext,
   createElement,
   useContext,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
 
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 import type { SearchMiddleware } from "./middleware";
 import { SearchStore } from "./store";
 import type {
@@ -97,14 +97,14 @@ export function SearchStateProvider(props: SearchStateProviderProps) {
     needsNotifyRef.current = store.updateState(location.search);
   }
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (needsNotifyRef.current) {
       needsNotifyRef.current = false;
       store.emit();
     }
   });
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     return () => {
       navigationQueue.destroy();
     };

--- a/packages/react-url-search-state/src/useIsomorphicLayoutEffect.ts
+++ b/packages/react-url-search-state/src/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,16 @@
+import { useEffect, useLayoutEffect } from "react";
+
+/**
+ * `useLayoutEffect` that degrades to `useEffect` on the server.
+ *
+ * React logs a warning when `useLayoutEffect` runs during server rendering
+ * (it can't do anything useful without a DOM). Layout effects never run on
+ * the server anyway, so falling back to `useEffect` there is behaviorally
+ * identical and silences the warning.
+ *
+ * The choice is made once at module load based on the presence of `window`,
+ * which is safe because an environment does not switch between having and
+ * not having a DOM at runtime.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/packages/react-url-search-state/tests/ssr.hydration.test.tsx
+++ b/packages/react-url-search-state/tests/ssr.hydration.test.tsx
@@ -1,0 +1,67 @@
+import { act } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SearchStateProvider } from "../src";
+import type { Path, SearchStateAdapter } from "../src";
+import { useSearch } from "./testHelpers";
+
+/**
+ * Verifies the client hydrates server-rendered markup with no mismatch. Because
+ * both the server and the client initialize the store from the same URL, the
+ * first client render must produce identical output — the property that makes
+ * URL search params a clean fit for SSR.
+ */
+
+function createStaticAdapter(search: string): SearchStateAdapter {
+  const location = { pathname: "/", search, hash: "" };
+  const noop = (_state: unknown, _path: Path) => {};
+  return { location, pushState: noop, replaceState: noop };
+}
+
+function Filters() {
+  const { page, tab } = useSearch();
+  return <div data-testid="filters">{`page:${page} tab:${tab}`}</div>;
+}
+
+describe("SSR — client hydration", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    container.remove();
+  });
+
+  it("hydrates server markup without a mismatch warning", () => {
+    const adapter = createStaticAdapter("?tab=preview&page=3");
+    const useAdapter = () => adapter;
+    const tree = (
+      <SearchStateProvider adapter={useAdapter}>
+        <Filters />
+      </SearchStateProvider>
+    );
+
+    container.innerHTML = renderToString(tree);
+    const serverHtml = container.innerHTML;
+
+    act(() => {
+      hydrateRoot(container, tree);
+    });
+
+    // React logs a console.error on any hydration mismatch; none expected.
+    expect(errorSpy).not.toHaveBeenCalled();
+    // DOM untouched by hydration — server and client agree.
+    expect(container.innerHTML).toBe(serverHtml);
+    expect(container.querySelector("[data-testid=filters]")?.textContent).toBe(
+      "page:3 tab:preview",
+    );
+  });
+});

--- a/packages/react-url-search-state/tests/ssr.server.test.tsx
+++ b/packages/react-url-search-state/tests/ssr.server.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SearchStateProvider } from "../src";
+import type { Path, SearchStateAdapter } from "../src";
+import { useSearch } from "./testHelpers";
+
+/**
+ * These tests run in a real server-like environment (no `window`/DOM) to catch
+ * anything that only breaks outside the browser — the `useLayoutEffect` SSR
+ * warning, accidental `window`/`document` access, or unstable snapshots that
+ * would throw during `renderToString`.
+ */
+
+// A static, hook-shaped adapter built from a known search string. Navigation is
+// a no-op because there is nowhere to navigate to on the server.
+function createStaticAdapter(search: string): SearchStateAdapter {
+  const location = { pathname: "/", search, hash: "" };
+  const noop = (_state: unknown, _path: Path) => {};
+  return { location, pushState: noop, replaceState: noop };
+}
+
+function Filters() {
+  const { page, tab } = useSearch();
+  return <div>{`page:${page} tab:${tab}`}</div>;
+}
+
+describe("SSR — server render (no DOM)", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("renders validated state from the request URL on first paint", () => {
+    const adapter = createStaticAdapter("?tab=preview&page=3");
+    const useAdapter = () => adapter;
+
+    const html = renderToString(
+      <SearchStateProvider adapter={useAdapter}>
+        <Filters />
+      </SearchStateProvider>,
+    );
+
+    // Correct state on the server — no flash of defaults, no async hydration.
+    expect(html).toContain("page:3");
+    expect(html).toContain("tab:preview");
+  });
+
+  it("applies validator defaults synchronously for missing params", () => {
+    const adapter = createStaticAdapter("");
+    const useAdapter = () => adapter;
+
+    const html = renderToString(
+      <SearchStateProvider adapter={useAdapter}>
+        <Filters />
+      </SearchStateProvider>,
+    );
+
+    expect(html).toContain("page:1");
+    expect(html).toContain("tab:details");
+  });
+
+  it("does not emit React warnings during server render", () => {
+    const adapter = createStaticAdapter("?page=2");
+    const useAdapter = () => adapter;
+
+    renderToString(
+      <SearchStateProvider adapter={useAdapter}>
+        <Filters />
+      </SearchStateProvider>,
+    );
+
+    // Would fire if `useLayoutEffect` were used directly on the server.
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not reference window/document at module load or render", () => {
+    // `window` is genuinely absent in this environment.
+    expect(typeof window).toBe("undefined");
+
+    const adapter = createStaticAdapter("?page=2");
+    const useAdapter = () => adapter;
+
+    expect(() =>
+      renderToString(
+        <SearchStateProvider adapter={useAdapter}>
+          <Filters />
+        </SearchStateProvider>,
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Makes the core library SSR-safe and documents how URL-based search state fits SSR. This is the "Tier 0" safety pass — the shared foundation before any framework-specific SSR adapters.

- Add `useIsomorphicLayoutEffect` (a `useLayoutEffect` that degrades to `useEffect` when there's no `window`) and use it in `SearchStateProvider`. This silences React 18's *"useLayoutEffect does nothing on the server"* warning during server render. React 19 already dropped that warning, but the peer range is `^18 || ^19`, so the shim is still correct.
- Add SSR test coverage.
- Add a **Server-Side Rendering** section to the README.

## Why the core needs almost nothing else

Two findings from the audit worth calling out:

- The main worry from the prior analysis — `getServerSnapshot` returning an uncached value — **is not a real bug.** The validation cache keys on the state object reference and `replaceEqualDeep` stabilizes selector output, so snapshots are already referentially stable across calls.
- The core already never touches `window`/`document`/`localStorage` during render or module load (`requestAnimationFrame` is guarded, `debug.ts` is `try/catch`'d). The only genuine gap was the raw `useLayoutEffect`.

Because state *is* the request URL and `validateSearch` is pure, the server and client feed the same URL into the same function and get an identical validated object — the hydration contract is satisfied by design. "Does the server know the URL?" stays a router/framework concern, delegated to the adapter boundary.

## Tests

- `ssr.server.test.tsx` — renders in a real no-DOM env (`@vitest-environment node`): asserts state comes from the request URL, defaults apply synchronously, no React warnings, no `window` access.
- `ssr.hydration.test.tsx` — asserts server markup hydrates with no mismatch.

203/203 tests pass. `tsc -b` and the package build are clean.

> **Note:** `npm run lint` and the root `npm run build` fail on `main` today (ESLint flat-config loader crash; root `vite build` expects a nonexistent `index.html`). Both are pre-existing and unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)