### PR TITLE
docs: refresh CLAUDE.md and AGENTS.md to match current repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,61 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- Core library: `packages/react-url-search-state/src/`
-- Tests: `packages/react-url-search-state/tests/`
-- Router adapters: `packages/react-url-search-state-adapter-*/`
-- Examples: `examples/`
-- Build output: `packages/*/dist/`; coverage: `coverage/`
+Typed URL search param state for React — router-agnostic core plus per-router adapters. Alpha (core `0.1.0-alpha.6`), public API not yet stable. This file is for any AI coding agent; `CLAUDE.md` has the fuller architecture reference.
 
-## Architecture Overview
-- The core package manages parsing, validation, and URL updates; adapters bridge router APIs.
-- `SearchStateProvider` wires `SearchStore`, middleware, and a validation cache.
-- Reads: `useSearch` subscribes via `useSyncExternalStore`, validates, and optionally selects a slice.
-- Writes: `useNavigate` queues updates, batches in `requestAnimationFrame`, runs middleware, then calls adapter `pushState`/`replaceState`.
-- Validation is type-first and runtime-optional; parsing is permissive and preserves unknown params.
+## Project Structure & Modules
+- Core library: `packages/react-url-search-state/src/` (tests in `../tests/`).
+- Router adapters: `packages/react-url-search-state-adapter-*/src/*Adapter.tsx`.
+- Examples (one runnable app per router): `examples/{react-router-dom-v5,-v6,-v7,wouter-v3}/`.
+- Build output: `packages/*/dist/`; coverage: `coverage/`.
+- npm workspaces with `nohoist` for `react-router-dom` and `wouter`.
 
-## Build, Test, and Development Commands
-Run from repo root:
-- `npm run dev`: Vite dev server for examples.
-- `npm run build`: typecheck + build (`tsc -b` + `vite build`).
-- `npm run build:types`: emit declarations only.
-- `npm run lint`: ESLint.
-- `npm test`: Vitest watch mode.
-- `npm run test:run`: tests once.
-- `npm run test:watch`: watch with verbose reporter.
+## Architecture (short)
+- Core parses/validates/updates URL search state; adapters bridge each router's `useLocation`/`useNavigate` to the `SearchStateAdapter` interface.
+- `SearchStateProvider` wires `SearchStore`, middleware, and the validation cache; store↔URL sync uses an isomorphic layout effect (SSR-safe).
+- Reads: `useSearch` subscribes via `useSyncExternalStore`, validates, optionally selects a slice.
+- Writes: `useNavigate` queues updates, batches them in `requestAnimationFrame`, runs middleware, then calls adapter `pushState`/`replaceState`.
+- Validation is type-first and runtime-optional; parsing is permissive and preserves unknown params. Serialization is overridable via `parseSearchWith`/`stringifySearchWith`.
 
-## Coding Style & Naming Conventions
-- TypeScript-first, `type: module`.
-- Prettier for formatting; ESLint for linting (`eslint.config.js`).
-- Hooks are `useX`; adapters are `react-url-search-state-adapter-<router>`.
-- Core package must not add non-React runtime deps.
+## Build, Test & Dev Commands (from repo root)
+- `npm run build`: full build (`build:core` then `build:adapters`).
+- `npm run build:core` / `npm run build:adapters` / `npm run build:types`: scoped builds / declarations only.
+- `npm run lint`: ESLint (flat config in `eslint.config.js`).
+- `npm test`: Vitest watch. `npm run test:run`: single pass (use this to verify).
+- Examples run per-directory: `cd examples/<router> && npm run dev` (there is no working root dev server).
 
-## Testing Guidelines
-- Vitest + jsdom + `@testing-library/react`.
-- Test files: `packages/react-url-search-state/tests/*.test.ts(x)`.
-- Prefer `testHelpers.tsx` helpers (e.g., `createTestAdapter`, `renderWithSearchProvider`).
-- Add coverage for hook behavior, batching/queue changes, and parse/stringify edge cases.
+## Coding Style & Conventions
+- TypeScript-first, ESM (`type: module`); Prettier for formatting (default config).
+- Hooks named `useX`; adapter packages named `react-url-search-state-adapter-<router>`.
+- **Core must not add non-React runtime deps and must never import a router.**
+- `_`-prefixed unused bindings and silent `catch {}` are allowed by design; `any` is a warning (used deliberately in type utilities and TanStack-copied code).
+- Keep the type-first / runtime-optional contract: no strict-mode rejection, no throwing on parse failure.
 
-## Commit & Pull Request Guidelines
-- Commit prefixes: `feat:`, `fix:`, `perf:`, `test:`, `chore:`.
-- Short, action-oriented subjects; include scope or issue numbers when useful.
-- PRs should describe behavior changes, include tests or rationale, and link issues.
+## Testing Expectations
+- Vitest + jsdom + `@testing-library/react`; files: `packages/react-url-search-state/tests/*.test.ts(x)`.
+- Prefer `testHelpers.tsx` (`createTestAdapter`, `renderWithSearchProvider`).
+- Cover hook behavior, batching/queue changes, parse/stringify edge cases, and SSR paths when relevant.
+- All behavior changes require tests.
 
-## Key Files to Know
-- `packages/react-url-search-state/src/context.ts`: provider + store wiring.
-- `packages/react-url-search-state/src/useSearch.ts`: read hook + selector stability.
-- `packages/react-url-search-state/src/useNavigate.ts`: batching, middleware, navigation.
-- `packages/react-url-search-state/src/validation.ts`: validator helpers + cache.
+## Safe Editing Rules
+- Don't introduce router or non-React deps into the core package.
+- Don't hand-edit `dist/`, `coverage/`, or `package-lock.json`.
+- Don't change public exports in `src/index.ts` or the validation/serialization contract without calling it out.
+- Keep changes scoped; match existing file/idiom conventions.
+
+## Validate Before Finishing
+Run and ensure green: `npm run lint && npm run build && npm run test:run`.
+CI (`.github/workflows/ci.yml`) runs the same across Node 20 & 22. Note: CI deletes the macOS-generated `package-lock.json` and does a fresh `npm install` (Linux native-dep resolution, npm/cli#4828) — don't rely on `npm ci` on Linux.
+
+## Commit & PR Guidelines
+- Conventional prefixes: `feat:`, `fix:`, `perf:`, `test:`, `chore:`, `docs:`; short, action-oriented subjects; link issues/scope when useful.
+- PRs describe behavior changes, include tests or rationale, and note any public-API or contract impact.
+
+## Key Files
+- `src/context.ts`: provider + store wiring.
+- `src/store.ts` / `src/navigationQueue.ts`: state store and RAF batching.
+- `src/useSearch.ts`: read hook + selector stability.
+- `src/useNavigate.ts`: batching, middleware, navigation.
+- `src/middleware.ts`: middleware pipeline + built-ins.
+- `src/validation.ts`: validator helpers + `ValidatedSearchCache`.
+- `src/utils.ts`: serialization, `replaceEqualDeep`, `deepEqual`.
 - Adapters: `packages/react-url-search-state-adapter-*/src/*Adapter.tsx`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,19 @@
 # CLAUDE.md
 
-Typed URL search param state management for React. Router-agnostic via an adapter pattern with JSON parsing, validation, structural sharing, and batched navigation. Currently in alpha (0.1.0-alpha.2) — public API is not yet stable.
+Typed URL search param state management for React. Router-agnostic via an adapter pattern with JSON parsing, validation, structural sharing, and batched navigation. SSR-safe. Currently in alpha (core is `0.1.0-alpha.6`) — public API is not yet stable.
 
 ## Commands
 
-All commands run from the repo root.
+All commands run from the repo root unless noted.
 
 ```bash
-npm run build          # tsc -b && vite build
+npm run build          # build:core then build:adapters (full publishable build)
+npm run build:core     # build core package only
+npm run build:adapters # build all adapter packages (--if-present)
+npm run build:types    # tsc -p tsconfig.json (declarations only)
 npm run lint           # eslint .
 npm test               # vitest (watch mode)
-npm run test:run       # vitest run (single pass)
+npm run test:run       # vitest run (single pass — use this for CI-style checks)
 npm run test:watch     # vitest --watch --reporter verbose
 
 # Single file or pattern
@@ -18,36 +21,53 @@ npx vitest run packages/react-url-search-state/tests/useSearch.test.tsx
 npx vitest run -t "pattern"
 ```
 
+Per-package `build` (run inside a package dir or via `--workspace`) is `tsc -b && vite build`, emitting dual ESM/CJS + declarations.
+
+There is no working root `dev` server (no root `vite.config`). Run examples individually: `cd examples/<router> && npm run dev`.
+
 ## Monorepo Structure
 
-npm workspaces with `nohoist` for `react-router-dom` and `wouter`.
+npm workspaces (`workspaces.packages: ["packages/*"]`) with `nohoist` for `react-router-dom` and `wouter` so each adapter/example resolves its own router version.
 
-- `packages/react-url-search-state/` — Core library. **Zero non-React deps — enforce this strictly.**
+- `packages/react-url-search-state/` — Core library. **Zero non-React runtime deps — enforce this strictly.**
 - `packages/react-url-search-state-adapter-react-router-dom-v5/` — React Router v5 adapter
 - `packages/react-url-search-state-adapter-react-router-dom-v6/` — React Router v6 adapter
 - `packages/react-url-search-state-adapter-react-router-dom-v7/` — React Router v7 adapter
 - `packages/react-url-search-state-adapter-wouter-v3/` — Wouter v3 adapter
-- `examples/` — Example apps per router
+- `examples/{react-router-dom-v5,react-router-dom-v6,react-router-dom-v7,wouter-v3}/` — one runnable example app per router
+
+Adapters and examples pin their router as a peer/dev dep; the core package declares only a `react` peer dep (`^18 || ^19`).
 
 ## Architecture
 
 ### Adapter Pattern
 
-Adapters are thin wrappers around router-specific hooks (`useLocation`, `useNavigate`) exposing a uniform `SearchStateAdapter` interface (`location`, `pushState`, `replaceState`). **The core library never imports any router directly — keep it that way.**
+Adapters are thin wrappers around router-specific hooks (`useLocation`, `useNavigate`) exposing a uniform `SearchStateAdapter` interface (`location`, `pushState`, `replaceState`). Each adapter is a single `*Adapter.tsx` in its `src/`. **The core library never imports any router directly — keep it that way.**
 
 ### Core Data Flow
 
-1. **`SearchStateProvider`** (context.ts) — receives adapter, creates `SearchStore`, syncs with `location.search`
-2. **`SearchStore`** (store.ts) — parses URL search string into state, manages subscribers, applies structural sharing via `replaceEqualDeep`
-3. **Hooks** read via `useSyncExternalStore`, write through the adapter's push/replace methods
+1. **`SearchStateProvider`** (`context.ts`) — receives the adapter, creates a `SearchStore`, and syncs it with `location.search`.
+2. **`SearchStore`** (`store.ts`) — parses the URL search string into state, manages subscribers, applies structural sharing via `replaceEqualDeep`.
+3. **Hooks** read via `useSyncExternalStore` and write through the adapter's push/replace methods.
 
-### Key Hooks/utilities (`src/`)
+Store↔URL syncing uses `useIsomorphicLayoutEffect` (`useLayoutEffect` in the browser, `useEffect` on the server) so the core renders cleanly under SSR without React layout-effect warnings.
+
+### Public API surface (`src/index.ts`)
+
+Value exports: `SearchStateProvider`, `createSearchUtils`, `buildSearchString`, `setDebug`, `retainSearchParams`, `stripSearchParams`, `runMiddleware`, `useSearch`, `useNavigate`, `useSetSearch`, `useSearchParamState`, `deepEqual`, `parseSearchWith`, `stringifySearchWith`, `composeValidateSearch`, `defineValidateSearch`, `ValidationError`.
+
+Key hooks/utilities:
 
 - `useSearch` — read validated state with optional `select` for slicing
 - `useNavigate` — full navigation (search, pathname, hash) with merge/replace strategies
 - `useSetSearch` — search-only updates convenience wrapper
 - `useSearchParamState` — `useState`-like API for a single param
 - `buildSearchString` — pure utility for generating validated URL search strings for link building
+- `setDebug(enabled)` — toggles the internal debug logger (`debug.ts`); also auto-enabled when the `react-url-search-state:debug` localStorage key is present
+
+### Custom Serialization
+
+`utils.ts` exposes `parseSearchWith(parser)` and `stringifySearchWith(stringifier)` factories. The defaults `parseSearch`/`stringifySearch` are built from `JSON.parse`/`JSON.stringify`. `SearchStateProvider` accepts `parseSearch`/`stringifySearch` props to override serialization (e.g. to plug in a different codec). Parsing is permissive: a failed parse leaves the value as its raw string.
 
 ### Strictness Philosophy (Confirmed Alignment with @tanstack/react-router)
 
@@ -55,34 +75,47 @@ This library mirrors @tanstack/react-router's search param strictness model: **t
 
 1. **TypeScript enforcement is strong.** `defineValidateSearch` produces `ValidateSearchFn<T>` which flows through all hooks via generics. Invalid usage is caught at compile time.
 2. **Runtime enforcement is optional.** `ValidationError` is only thrown when a provided validator function fails. No validator = no runtime error. Parse errors are silent.
-3. **Default parsing is permissive.** `parseSearch` uses JSON-ish parsing with silent fallback — failed JSON parse leaves the value as a string. Type coercion (`"true"` → `true`, `"123"` → `123`) is lenient.
+3. **Default parsing is permissive.** Failed JSON parse leaves the value as a string. Type coercion (`"true"` → `true`, `"123"` → `123`) is lenient.
 4. **Unknown params are allowed.** The parser returns all decoded params; the validator returns only declared fields. No strict-mode rejection exists.
 
-This gives strong editor feedback while keeping runtime behavior configurable — tight TS types for DX, runtime validation only when a validator is provided, and a forgiving default serializer.
+Strong editor feedback with configurable runtime behavior — tight TS types for DX, runtime validation only when a validator is provided, and a forgiving default serializer.
 
 ### Middleware Pipeline
 
 `SearchMiddleware` functions intercept navigations via an onion model with `next()` chaining. Each middleware can transform `{ search, path, options }` or return `null` to cancel. Middleware composes at three levels: **Provider → Factory → Hook** (outermost to innermost). `onBeforeNavigate` fires after middleware with transformed values and is skipped on cancellation.
 
-Built-in utilities: `retainSearchParams(keys | true)` preserves params across navigations; `stripSearchParams(defaults)` removes params matching defaults.
+Built-in utilities: `retainSearchParams(keys | true)` preserves params across navigations; `stripSearchParams(defaults)` removes params matching defaults. `runMiddleware` is the exported composition primitive.
 
 Core implementation in `src/middleware.ts`. Wired into `useNavigate.ts` (RAF callback), `context.ts` (provider prop), and `createSearchUtils.ts` (factory option).
 
 ### Other Key Patterns
 
 - **Factory:** `createSearchUtils()` pre-binds all hooks and utilities to a specific validator
-- **Validation:** `defineValidateSearch()` for type-safe validators; `composeValidateSearch()` for nested route composition; results cached via `ValidatedSearchCache` (WeakMap)
-- **Batching:** Multiple navigate calls in the same frame queue and flush on next `requestAnimationFrame` as a single navigation
-- **Structural sharing:** `replaceEqualDeep()` preserves referential equality for unchanged subtrees
+- **Validation:** `defineValidateSearch()` for type-safe validators; `composeValidateSearch()` for nested route composition; results cached via `ValidatedSearchCache` (WeakMap in `validation.ts`)
+- **Batching:** `NavigationQueue` (`navigationQueue.ts`) queues navigate calls in the same frame and flushes them on the next `requestAnimationFrame` as a single navigation
+- **Structural sharing:** `replaceEqualDeep()` (`utils.ts`) preserves referential equality for unchanged subtrees
 
 ## Testing
 
-`packages/react-url-search-state/tests/` — Vitest + jsdom + @testing-library/react. Use `createTestAdapter()` and `renderWithSearchProvider()` from `testHelpers.tsx` for hook tests with a mock adapter. All changes should include tests.
+`packages/react-url-search-state/tests/` — Vitest + jsdom + @testing-library/react (config in `vitest.config.ts`; globals on, setup in `tests/setup.ts`). Use `createTestAdapter()` and `renderWithSearchProvider()` from `testHelpers.tsx` for hook tests with a mock adapter. SSR is covered by `ssr.server.test.tsx` / `ssr.hydration.test.tsx`; custom serialization by `customSerialization.test.tsx`. All changes should include tests.
+
+## CI
+
+`.github/workflows/ci.yml` runs on pushes to `main` and all PRs, matrixed over Node 20 & 22: `npm run lint`, `npm run build`, `npm run test:run`.
+
+**Gotcha:** the committed `package-lock.json` is generated on macOS and only records darwin native optional deps (rollup/esbuild). CI therefore deletes the lockfile and runs a fresh `npm install` so the runner resolves Linux binaries (npm/cli#4828). Don't assume `npm ci` works on Linux with the committed lock.
 
 ## Build Output
 
-Dual ESM (`dist/esm/index.js`) and CJS (`dist/cjs/index.cjs`) with co-located type declarations.
+Dual ESM (`dist/esm/index.js`) and CJS (`dist/cjs/index.cjs`) with co-located type declarations. Packages publish `dist` + `src`.
 
 ## TypeScript
 
-Strict mode: `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`. Module resolution: `bundler`. Path alias `react-url-search-state` → `packages/react-url-search-state/src`.
+Strict mode with `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`, `erasableSyntaxOnly`. Module resolution: `bundler`. Path alias `react-url-search-state` → `packages/react-url-search-state/src`.
+
+## How to approach edits here
+
+- Never add a router import or any non-React runtime dependency to the core package.
+- Prefer `_`-prefixed names for intentionally unused bindings; silent `catch {}` is allowed (permissive parsing). `any` is a warning, not an error — it's used deliberately in value-agnostic type utilities and TanStack-copied code (look for "Copied from" comments).
+- Keep the type-first / runtime-optional contract intact: don't add strict-mode rejection or throw on parse failures.
+- Add or update tests for any behavior change; validate with `npm run lint && npm run build && npm run test:run` before finishing.


### PR DESCRIPTION
## Summary

Refreshes both agent-guidance files so they accurately reflect the current codebase (core `0.1.0-alpha.6`). No code changes — docs only.

### CLAUDE.md
- Version `alpha.2` → `alpha.6`; noted SSR-safe support
- **Fixed build commands**: root `build` is `build:core` → `build:adapters` (the old `tsc -b && vite build` line described the *per-package* build). Added `build:core`, `build:adapters`, `build:types`
- Corrected dev-server guidance — there is no working root `vite.config`; examples run per-directory
- Documented new API surface: `setDebug`, `parseSearchWith`/`stringifySearchWith` custom serialization, `runMiddleware`, `deepEqual`, extracted `NavigationQueue`, and `useIsomorphicLayoutEffect` (SSR)
- Added a **CI** section (Node 20/22 lint/build/test) plus the macOS `package-lock.json` / `npm ci` gotcha
- Added a "How to approach edits" section

### AGENTS.md
- Made tool-agnostic and consistent with CLAUDE.md (no deep-architecture duplication)
- Fixed the misleading "root dev server" claim
- Added **Safe Editing Rules**, a **Validate Before Finishing** step, and refreshed **Key Files**

Both files were cross-checked for consistency; stale explicit test counts were dropped so they won't drift.

## Validation

All green locally on this branch's content:

- `npm run lint` — 0 errors (expected `any` / exhaustive-deps warnings only)
- `npm run build` — exit 0
- `npm run test:run` — 203 passed across 21 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)